### PR TITLE
Add nocolor() for non-console environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ second for when the expectation is negated.
 We then insert our 'empty' assertion into the `be` path -- the numeric keys of a path represent the
 possible expectations that can be chained.
 
+### Non-console environments
+
+If Lua is embedded in an application and does not run in a console environment that understands ANSI color escapes, the library can be required as follows:
+
+```lua
+local lust = require('lust').nocolor()
+```
+
 License
 ---
 

--- a/lust.lua
+++ b/lust.lua
@@ -14,6 +14,11 @@ local green = string.char(27) .. '[32m'
 local normal = string.char(27) .. '[0m'
 local function indent(level) return string.rep('\t', level or lust.level) end
 
+function lust.nocolor()
+  red, green, normal = '', '', ''
+  return lust
+end
+
 function lust.describe(name, fn)
   print(indent() .. name)
   lust.level = lust.level + 1


### PR DESCRIPTION
When Lua is embedded in an application and does not run in a console environment, the ANSI color escapes are irritating. With the added `nocolor()`, lust can be imported like `require('lust').nocolor()`.