### PR TITLE
Handle non-string error messages.

### DIFF
--- a/lust.lua
+++ b/lust.lua
@@ -44,7 +44,7 @@ function lust.it(name, fn)
   local label = success and 'PASS' or 'FAIL'
   print(indent() .. color .. label .. normal .. ' ' .. name)
   if err then
-    print(indent(lust.level + 1) .. red .. err .. normal)
+    print(indent(lust.level + 1) .. red .. tostring(err) .. normal)
   end
 
   for level = 1, lust.level do


### PR DESCRIPTION
It's possible to throw non-string error messages in Lua. And that makes lust fail in handling them.
I've added a wrapping `tostring` so it's made sure the error has been made a string that can be displayed.

Do you have any other solutions in-mind?